### PR TITLE
Merge Changes to Remove Comments from XML

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,7 @@ name 'Net-SAML2';
 all_from 'lib/Net/SAML2.pm';
 
 requires 'XML::XPath';
+requires 'XML::Tidy';
 requires 'XML::Generator';
 requires 'XML::Writer';
 requires 'Crypt::OpenSSL::RSA';

--- a/README
+++ b/README
@@ -6,6 +6,7 @@ supporting the Web Browser SSO profile.
 Major dependencies:
 
  * XML::XPath
+ * XML::Tidy
  * Crypt::OpenSSL::RSA
  * Crypt::OpenSSL::X509
  * Crypt::OpenSSL::VerifyX509

--- a/lib/Net/SAML2/Binding/POST.pm
+++ b/lib/Net/SAML2/Binding/POST.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Moose;
 use MooseX::Types::Moose qw/ Str /;
+use Net::SAML2::XML::Util qw/ no_comments /;
 
 =head1 NAME
 
@@ -57,7 +58,7 @@ sub handle_response {
     my ($self, $response) = @_;
 
     # unpack and check the signature
-    my $xml = decode_base64($response);
+    my $xml = no_comments(decode_base64($response));
     my $xml_opts = { x509 => 1 };
     $xml_opts->{ cert_text } = $self->cert_text if ($self->cert_text);
     my $x = Net::SAML2::XML::Sig->new($xml_opts);

--- a/lib/Net/SAML2/Binding/POST.pm
+++ b/lib/Net/SAML2/Binding/POST.pm
@@ -64,11 +64,11 @@ sub handle_response {
     my $x = Net::SAML2::XML::Sig->new($xml_opts);
     my $ret = $x->verify($xml);
     die "signature check failed" unless $ret;
-    
+
     if ($self->cacert) {
         my $cert = $x->signer_cert
             or die "Certificate not provided and not in SAML Response, cannot validate";
-    
+
         my $ca = Crypt::OpenSSL::VerifyX509->new($self->cacert);
         if ($ca->verify($cert)) {
             return sprintf("%s (verified)", $cert->subject);
@@ -76,7 +76,7 @@ sub handle_response {
             return 0;
         }
     }
-    
+
     return 1;
 }
 

--- a/lib/Net/SAML2/Binding/SOAP.pm
+++ b/lib/Net/SAML2/Binding/SOAP.pm
@@ -2,6 +2,7 @@ package Net::SAML2::Binding::SOAP;
 use Moose;
 use MooseX::Types::Moose qw/ Str Object /;
 use MooseX::Types::URI qw/ Uri /;
+use Net::SAML2::XML::Util qw/ no_comments /;
 
 =head1 NAME
 
@@ -124,7 +125,7 @@ sub handle_response {
     my $subject = sprintf("%s (verified)", $cert->subject);
 
     # parse the SOAP response and return the payload
-    my $parser = XML::XPath->new( xml => $response );
+    my $parser = XML::XPath->new( xml => no_comments($response) );
     $parser->set_namespace('soap-env', 'http://schemas.xmlsoap.org/soap/envelope/');
     $parser->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
         
@@ -143,7 +144,7 @@ Accepts a string containing the complete SOAP request.
 sub handle_request {
     my ($self, $request) = @_;
         
-    my $parser = XML::XPath->new( xml => $request );
+    my $parser = XML::XPath->new( xml => no_comments($request) );
     $parser->set_namespace('soap-env', 'http://schemas.xmlsoap.org/soap/envelope/');
     $parser->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
 

--- a/lib/Net/SAML2/IdP.pm
+++ b/lib/Net/SAML2/IdP.pm
@@ -127,12 +127,12 @@ sub new_from_xml {
         $data->{NameIDFormat}->{unspecified} = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
         $data->{DefaultFormat} = 'unspecified' unless exists $data->{DefaultFormat};
     }
-    
+ 
     for my $key (
         $xpath->findnodes('//md:EntityDescriptor/md:IDPSSODescriptor/md:KeyDescriptor'))
     {
         my $use = $key->getAttribute('use') || 'signing';
-        
+ 
         # We can't select by ds:KeyInfo/ds:X509Data/ds:X509Certificate
         # because of https://rt.cpan.org/Public/Bug/Display.html?id=8784
         my ($text)
@@ -173,7 +173,7 @@ sub new_from_xml {
 
 sub BUILD {
     my($self) = @_;
-    
+ 
     if ($self->cacert) {
         my $ca = Crypt::OpenSSL::VerifyX509->new($self->cacert);
 

--- a/lib/Net/SAML2/IdP.pm
+++ b/lib/Net/SAML2/IdP.pm
@@ -2,6 +2,7 @@ package Net::SAML2::IdP;
 use Moose;
 use MooseX::Types::Moose qw/ Str Object HashRef ArrayRef /;
 use MooseX::Types::URI qw/ Uri /;
+use Net::SAML2::XML::Util qw/ no_comments /;
 
 =head1 NAME
 
@@ -59,7 +60,7 @@ sub new_from_url {
 
     my $res = $ua->request($req);
     die "no metadata" unless $res->is_success;
-    my $xml = $res->content;
+    my $xml = no_comments($res->content);
 
     return $class->new_from_xml(xml => $xml, cacert => $args{cacert});
 }
@@ -74,7 +75,7 @@ document.
 sub new_from_xml {
     my($class, %args) = @_;
 
-    my $xpath = XML::XPath->new(xml => $args{xml});
+    my $xpath = XML::XPath->new(xml => no_comments($args{xml}));
     $xpath->set_namespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
     $xpath->set_namespace('ds', 'http://www.w3.org/2000/09/xmldsig#');
 

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -5,7 +5,7 @@ use MooseX::Types::DateTime qw/ DateTime /;
 use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use DateTime;
 use DateTime::Format::XSD;
-use Net::SAML2::XML::Util;
+use Net::SAML2::XML::Util qw/ no_comments /;
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
@@ -54,7 +54,7 @@ XML data
 sub new_from_xml {
     my($class, %args) = @_;
 
-    my $xpath = XML::XPath->new(xml => no_comments($args{xml}->no_comments()));
+    my $xpath = XML::XPath->new(xml => no_comments($args{xml}));
 
     $xpath->set_namespace('saml',  'urn:oasis:names:tc:SAML:2.0:assertion');
     $xpath->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -142,22 +142,4 @@ sub valid {
     return 1;
 }
 
-#=head2 no_comments( $xml )
-
-#Returns the XML passed as plain XML with the comments removed
-
-#This is to remediate CVE-2017-11427 XML Comments can allow for
-#authentication bypass in SAML2 implementations
-
-#=cut
-
-#sub no_comments {
-#    my ($self, $xml) = @_;
-#
-#    # Remove comments from XML to mitigate XML comment auth bypass
-#    my $tidy_obj = XML::Tidy->new(xml => $xml);
-#    $tidy_obj->prune('//comment()');
-    #    return $tidy_obj->toString();
-    #}
-
 1;

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -5,6 +5,7 @@ use MooseX::Types::DateTime qw/ DateTime /;
 use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use DateTime;
 use DateTime::Format::XSD;
+use Net::SAML2::XML::Util;
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
@@ -53,7 +54,8 @@ XML data
 sub new_from_xml {
     my($class, %args) = @_;
 
-    my $xpath = XML::XPath->new(xml => $args{xml});
+    my $xpath = XML::XPath->new(xml => no_comments($args{xml}->no_comments()));
+
     $xpath->set_namespace('saml',  'urn:oasis:names:tc:SAML:2.0:assertion');
     $xpath->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
 
@@ -139,5 +141,23 @@ sub valid {
 
     return 1;
 }
+
+#=head2 no_comments( $xml )
+
+#Returns the XML passed as plain XML with the comments removed
+
+#This is to remediate CVE-2017-11427 XML Comments can allow for
+#authentication bypass in SAML2 implementations
+
+#=cut
+
+#sub no_comments {
+#    my ($self, $xml) = @_;
+#
+#    # Remove comments from XML to mitigate XML comment auth bypass
+#    my $tidy_obj = XML::Tidy->new(xml => $xml);
+#    $tidy_obj->prune('//comment()');
+    #    return $tidy_obj->toString();
+    #}
 
 1;

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -128,10 +128,10 @@ sub valid {
 
     return 0 unless defined $audience;
     return 0 unless($audience eq $self->audience);
-    
+ 
     return 0 unless !defined $in_response_to
         or $in_response_to eq $self->in_response_to;
-    
+
     my $now = DateTime::->now;
 
     # not_before is "NotBefore" element - exact match is ok

--- a/lib/Net/SAML2/Protocol/AuthnRequest.pm
+++ b/lib/Net/SAML2/Protocol/AuthnRequest.pm
@@ -73,8 +73,8 @@ sub as_xml {
     my ($self) = @_;
     my $saml = 'urn:oasis:names:tc:SAML:2.0:assertion';
     my $samlp = 'urn:oasis:names:tc:SAML:2.0:protocol';
-    my $x = XML::Writer->new( 
-        OUTPUT => 'self', 
+    my $x = XML::Writer->new(
+        OUTPUT => 'self',
         NAMESPACES => 1,
         FORCED_NS_DECLS => [$saml, $samlp],
         PREFIX_MAP => {
@@ -88,9 +88,9 @@ sub as_xml {
             IssueInstant => $self->issue_instant,
             Version => '2.0',
         };
-        
+
         my $issuer_attrs = {};
-        
+
         my $protocol_bindings = {
             'HTTP-POST' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
         };
@@ -119,7 +119,7 @@ sub as_xml {
                 }
             }
         }
-    
+
     $x->startTag([$samlp, 'AuthnRequest'], %$req_atts);
     $x->dataElement([$saml, 'Issuer'], $self->issuer, %$issuer_attrs);
     if ($self->nameid) {

--- a/lib/Net/SAML2/Protocol/LogoutRequest.pm
+++ b/lib/Net/SAML2/Protocol/LogoutRequest.pm
@@ -2,6 +2,7 @@ package Net::SAML2::Protocol::LogoutRequest;
 use Moose;
 use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use MooseX::Types::URI qw/ Uri /;
+use Net::SAML2::XML::Util qw/ no_comments /;
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
@@ -75,7 +76,7 @@ XML data
 sub new_from_xml {
     my ($class, %args) = @_;
 
-    my $xpath = XML::XPath->new( xml => $args{xml} );
+    my $xpath = XML::XPath->new( xml => no_comments($args{xml}) );
     $xpath->set_namespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
     $xpath->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
 

--- a/lib/Net/SAML2/Protocol/LogoutResponse.pm
+++ b/lib/Net/SAML2/Protocol/LogoutResponse.pm
@@ -2,6 +2,7 @@ package Net::SAML2::Protocol::LogoutResponse;
 use Moose;
 use MooseX::Types::Moose qw/ Str /;
 use MooseX::Types::URI qw/ Uri /;
+use Net::SAML2::XML::Util qw/ no_comments /;
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
@@ -69,7 +70,7 @@ XML data
 sub new_from_xml {
     my ($class, %args) = @_;
      
-    my $xpath = XML::XPath->new( xml => $args{xml} );
+    my $xpath = XML::XPath->new( xml => no_comments($args{xml}) );
     $xpath->set_namespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
     $xpath->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
 

--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -37,7 +37,7 @@ base for all SP service URLs
 
 =item B<id>
 
-SP's identity URI. 
+SP's identity URI.
 
 =item B<cert>
 

--- a/lib/Net/SAML2/XML/Sig.pm
+++ b/lib/Net/SAML2/XML/Sig.pm
@@ -177,7 +177,7 @@ sub verify {
                     if ( ! $self->$verify_method($keyinfo_nodeset->get_node(0), $signed_info_canon, $signature) ) {
                         print STDERR "Failed to verify using $verify_method\n";
                         return 0;
-                    } 
+                    }
                     last;
                 }
             }
@@ -192,7 +192,7 @@ sub verify {
         my $digest    = $self->{digest_method}->($canonical);
         return 0 unless ($refdigest eq _trim(encode_base64($digest, '')));
     }
-    
+
     return 1;
 }
 

--- a/lib/Net/SAML2/XML/Util.pm
+++ b/lib/Net/SAML2/XML/Util.pm
@@ -1,5 +1,22 @@
 package Net::SAML2::XML::Util;
 
+use strict;
+use warnings;
+
+use XML::Tidy;
+
+# use 'our' on v5.6.0
+use vars qw($VERSION @EXPORT_OK %EXPORT_TAGS $DEBUG);
+
+$DEBUG = 0;
+$VERSION = '0.23_02';
+
+# We are exporting functions
+use base qw/Exporter/;
+
+# Export list - to allow fine tuning of export table
+@EXPORT_OK = qw( no_comments );
+
 =head1 NAME
 
 Net::SAML2::XML::Util - XML Util class.
@@ -22,7 +39,7 @@ authentication bypass in SAML2 implementations
 =cut
 
 sub no_comments {
-    my ($self, $xml) = @_;
+    my $xml = shift;
 
     # Remove comments from XML to mitigate XML comment auth bypass
     my $tidy_obj = XML::Tidy->new(xml => $xml);
@@ -30,4 +47,4 @@ sub no_comments {
     return $tidy_obj->toString();
 }
 
-__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/Net/SAML2/XML/Util.pm
+++ b/lib/Net/SAML2/XML/Util.pm
@@ -1,0 +1,33 @@
+package Net::SAML2::XML::Util;
+
+=head1 NAME
+
+Net::SAML2::XML::Util - XML Util class.
+
+=head1 SYNOPSIS
+
+  my $xml = no_comments($xml);
+
+=head1 METHODS
+
+=cut
+
+=head2 no_comments( $xml )
+
+Returns the XML passed as plain XML with the comments removed
+
+This is to remediate CVE-2017-11427 XML Comments can allow for
+authentication bypass in SAML2 implementations
+
+=cut
+
+sub no_comments {
+    my ($self, $xml) = @_;
+
+    # Remove comments from XML to mitigate XML comment auth bypass
+    my $tidy_obj = XML::Tidy->new(xml => $xml);
+    $tidy_obj->prune('//comment()');
+    return $tidy_obj->toString();
+}
+
+__PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
This adds a dependency on XML::Tidy to remove comments from XML.  Comments in the XML are not part of the signed document so can be used to insert potential auth bypasses